### PR TITLE
fix(VADC-537): handle archived NotFound exception in error logs

### DIFF
--- a/src/argowrapper/engine/argo_engine.py
+++ b/src/argowrapper/engine/argo_engine.py
@@ -290,29 +290,28 @@ class ArgoEngine:
         """
         try:
             archived_workflow_dict = self._get_archived_workflow_details_dict(uid)
-            try:
-                archived_workflow_details_nodes = archived_workflow_dict["status"].get(
-                    "nodes"
-                )
-                archived_workflow_errors = self._get_log_errors(
-                    archived_workflow_details_nodes
-                )
-                return archived_workflow_errors
-            except KeyError:
-                logger.info(
-                    f"Can't find the log of {workflow_name} workflow at archived workflow endpoint"
-                )
-                logger.info(
-                    f"Look up the log of {workflow_name} workflow at workflow endpoint"
-                )
-                active_workflow_log_return = self._get_workflow_log_dict(workflow_name)
-                active_workflow_details_nodes = active_workflow_log_return[
-                    "status"
-                ].get("nodes")
-                active_workflow_errors = self._get_log_errors(
-                    active_workflow_details_nodes
-                )
-                return active_workflow_errors
+            archived_workflow_details_nodes = archived_workflow_dict["status"].get(
+                "nodes"
+            )
+            archived_workflow_errors = self._get_log_errors(
+                archived_workflow_details_nodes
+            )
+            return archived_workflow_errors
+
+        except (KeyError, NotFoundException):
+            logger.info(
+                f"Can't find the log of {workflow_name} workflow at archived workflow endpoint"
+            )
+            logger.info(
+                f"Look up the log of {workflow_name} workflow at workflow endpoint"
+            )
+            active_workflow_log_return = self._get_workflow_log_dict(workflow_name)
+            active_workflow_details_nodes = active_workflow_log_return["status"].get(
+                "nodes"
+            )
+            active_workflow_errors = self._get_log_errors(active_workflow_details_nodes)
+            return active_workflow_errors
+
         except Exception as exception:
             logger.error(traceback.format_exc())
             logger.error(

--- a/test/test_argo_engine.py
+++ b/test/test_argo_engine.py
@@ -460,7 +460,6 @@ def test_argo_engine_get_workflow_log_succeeded():
     Fetch workflow error logs at workflow endpoint, but failed to fetch at archived workflow endpoint
     """
     engine = ArgoEngine()
-    mock_return_archived_wf = {"code": 5, "message": "not found"}
     mock_return_wf = {
         "status": {
             "phase": "Failed",

--- a/test/test_argo_engine.py
+++ b/test/test_argo_engine.py
@@ -427,7 +427,7 @@ def test_argo_engine_new_submit_failed():
 
 def test_argo_engine_get_archived_workflow_log_succeeded():
     """
-    Fetch workflow details at archived workflow endpoint
+    Fetch workflow error logs at archived workflow endpoint
     """
     engine = ArgoEngine()
     mock_return_archived_wf = {
@@ -457,7 +457,7 @@ def test_argo_engine_get_archived_workflow_log_succeeded():
 
 def test_argo_engine_get_workflow_log_succeeded():
     """
-    Fetch workflow details at workflow endpoint, but failed to fetch at archived workflow endpoint
+    Fetch workflow error logs at workflow endpoint, but failed to fetch at archived workflow endpoint
     """
     engine = ArgoEngine()
     mock_return_archived_wf = {"code": 5, "message": "not found"}
@@ -475,7 +475,7 @@ def test_argo_engine_get_workflow_log_succeeded():
         }
     }
     engine._get_archived_workflow_details_dict = mock.MagicMock(
-        return_value=mock_return_archived_wf
+        side_effect=NotFoundException("Not found")
     )
     engine._get_workflow_log_dict = mock.MagicMock(return_value=mock_return_wf)
     workflow_errors = engine.get_workflow_logs("active_wf", "wf_uid")


### PR DESCRIPTION
Jira Ticket: [VADC-537](https://ctds-planx.atlassian.net/browse/VADC-537)

### Bug Fixes

* Refactored logic around `NotFoundException` when getting error logs/messages from archive endpoint but the workflow is active and not present there


[VADC-537]: https://ctds-planx.atlassian.net/browse/VADC-537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ