### PR TITLE
Fix: add namespace to retry request

### DIFF
--- a/src/argowrapper/engine/argo_engine.py
+++ b/src/argowrapper/engine/argo_engine.py
@@ -205,6 +205,8 @@ class ArgoEngine:
             self.archive_api_instance.retry_archived_workflow(
                 uid=uid,
                 body=IoArgoprojWorkflowV1alpha1RetryArchivedWorkflowRequest(
+                    uid=uid,
+                    namespace=ARGO_NAMESPACE,
                     _check_type=False,
                 ),
                 _check_return_type=False,


### PR DESCRIPTION
Jira Ticket: [VADC-498](https://ctds-planx.atlassian.net/browse/VADC-498)

### Bug Fixes
- Add namespace to retry request to avoid error "an empty namespace may not be set when a resource name is provided"
