### PR TITLE
Fix: use name instead of uid for retry request

### DIFF
--- a/src/argowrapper/engine/argo_engine.py
+++ b/src/argowrapper/engine/argo_engine.py
@@ -203,9 +203,9 @@ class ArgoEngine:
         try:
             # Call the archived retry (will raise NotFoundException if workflow is not yet archived):
             self.archive_api_instance.retry_archived_workflow(
-                uid=uid,
+                name=workflow_name,
                 body=IoArgoprojWorkflowV1alpha1RetryArchivedWorkflowRequest(
-                    uid=uid,
+                    name=workflow_name,
                     namespace=ARGO_NAMESPACE,
                     _check_type=False,
                 ),


### PR DESCRIPTION
Jira Ticket: [VADC-498](https://ctds-planx.atlassian.net/browse/VADC-498)


### Bug Fixes
- Use workflow name instead of uid for retry request. This should fix error "Workflow already exists on cluster, use argo retry {name} instead"



[VADC-498]: https://ctds-planx.atlassian.net/browse/VADC-498?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ