### PR TITLE
Fix: use uid in the retry request and namespace in body

### DIFF
--- a/src/argowrapper/engine/argo_engine.py
+++ b/src/argowrapper/engine/argo_engine.py
@@ -203,7 +203,7 @@ class ArgoEngine:
         try:
             # Call the archived retry (will raise NotFoundException if workflow is not yet archived):
             self.archive_api_instance.retry_archived_workflow(
-                name=workflow_name,
+                uid=uid,
                 body=IoArgoprojWorkflowV1alpha1RetryArchivedWorkflowRequest(
                     name=workflow_name,
                     namespace=ARGO_NAMESPACE,


### PR DESCRIPTION
Jira Ticket: [VADC-498](https://ctds-planx.atlassian.net/browse/VADC-498)

### Bug Fixes
- use `uid` in the retry request and leave `namespace` in body to fix error "TypeError: ArchivedWorkflowServiceApi.retry_archived_workflow() missing 1 required positional argument: uid" while also addressing the empty namespace issue



[VADC-498]: https://ctds-planx.atlassian.net/browse/VADC-498?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ