### PR TITLE
Vadc 640 add error logs

### DIFF
--- a/src/argowrapper/argo_workflows_templates/header.yaml
+++ b/src/argowrapper/argo_workflows_templates/header.yaml
@@ -98,8 +98,7 @@ spec:
             "/commons-data/gds/chr19.merged.vcf.gz.gds",
             "/commons-data/gds/chr20.merged.vcf.gz.gds",
             "/commons-data/gds/chr21.merged.vcf.gz.gds",
-            "/commons-data/gds/chr22.merged.vcf.gz.gds",
-            "/commons-data/gds/chrX.merged.vcf.gz.gds"
+            "/commons-data/gds/chr22.merged.vcf.gz.gds"
           ]
   volumes:
     - name: workdir

--- a/src/argowrapper/engine/argo_engine.py
+++ b/src/argowrapper/engine/argo_engine.py
@@ -104,6 +104,8 @@ class ArgoEngine:
             artifact_name="main-logs",
             _check_return_type=False,
         )
+        print(type(api_response))
+        print(api_response)
         return api_response
 
     def _get_log_errors(self, uid: str, status_nodes_dict: Dict) -> List[Dict]:

--- a/src/argowrapper/engine/argo_engine.py
+++ b/src/argowrapper/engine/argo_engine.py
@@ -98,7 +98,7 @@ class ArgoEngine:
         return phase_return["status"].get("phase")
     
     def _get_workflow_node_artifact(self, id_discriminator: Literal['workflow', 'archived-workflows'], wf_id: str, node_id: str) -> str:
-        api_response = self.archive_api_instance.get_artifact_file(
+        api_response = self.artifact_api_instance.get_artifact_file(
             namespace=ARGO_NAMESPACE,
             id_discriminator=id_discriminator,
             id=wf_id,

--- a/src/argowrapper/engine/argo_engine.py
+++ b/src/argowrapper/engine/argo_engine.py
@@ -107,33 +107,33 @@ class ArgoEngine:
 
     def _get_log_errors(self, uid: str, status_nodes_dict: Dict) -> List[Dict]:
         errors = []
-        for pod_id, step in status_nodes_dict.items():
+        for node_id, step in status_nodes_dict.items():
             if step.get("phase") in ("Failed", "Error") and step.get("type")=="Retry":
                 message = (
                     step["message"] if step.get("message") else "No message provided"
                 )
-                pod_type = step.get("type")
-                pod_step = step.get("displayName")
-                pod_step_template =  step.get("templateName")
-                pod_phase = step.get("phase")
-                pod_outputs_mainlog = self._get_workflow_node_artifact(
+                node_type = step.get("type")
+                node_step = step.get("displayName")
+                node_step_template =  step.get("templateName")
+                node_phase = step.get("phase")
+                node_outputs_mainlog = self._get_workflow_node_artifact(
                     uid=uid,
-                    node_id=pod_id
+                    node_id=node_id
                 )
-                pod_log_interpreted = GWAS.interpret_gwas_workflow_error(
-                    step_name=pod_step,
-                    step_log=pod_outputs_mainlog
+                node_log_interpreted = GWAS.interpret_gwas_workflow_error(
+                    step_name=node_step,
+                    step_log=node_outputs_mainlog
                 )
                 errors.append(
                     {
                         "name": step.get("name"),
-                        "pod_id": pod_id,
-                        "pod_type": pod_type,
-                        "pod_phase": pod_phase,
-                        "step_name": pod_step,
-                        "step_template": pod_step_template,
+                        "pod_id": node_id,
+                        "pod_type": node_type,
+                        "pod_phase": node_phase,
+                        "step_name": node_step,
+                        "step_template": node_step_template,
                         "error_message": message,
-                        "error_interpreted": pod_log_interpreted
+                        "error_interpreted": node_log_interpreted
                     }
                 )
             else:

--- a/src/argowrapper/engine/argo_engine.py
+++ b/src/argowrapper/engine/argo_engine.py
@@ -122,7 +122,7 @@ class ArgoEngine:
                 )
                 pod_log_interpreted = GWAS.interpret_gwas_workflow_error(
                     step_name=pod_step,
-                    main_log=pod_outputs_mainlog
+                    step_log=pod_outputs_mainlog
                 )
                 errors.append(
                     {

--- a/src/argowrapper/engine/argo_engine.py
+++ b/src/argowrapper/engine/argo_engine.py
@@ -98,16 +98,12 @@ class ArgoEngine:
         return phase_return["status"].get("phase")
     
     def _get_workflow_node_artifact(self, uid: str, node_id: str) -> str:
-        api_response = self.artifact_api_instance.get_output_artifact_by_uid(
+        return self.artifact_api_instance.get_output_artifact_by_uid(
             uid=uid,
             node_id=node_id,
             artifact_name="main-logs",
             _check_return_type=False,
-        )
-        print(type(api_response))
-        print(type(api_response.read()))
-        print(api_response.read())
-        return api_response.read()
+        ).read().decode()
 
     def _get_log_errors(self, uid: str, status_nodes_dict: Dict) -> List[Dict]:
         errors = []

--- a/src/argowrapper/engine/argo_engine.py
+++ b/src/argowrapper/engine/argo_engine.py
@@ -105,8 +105,9 @@ class ArgoEngine:
             _check_return_type=False,
         )
         print(type(api_response))
-        print(api_response)
-        return api_response
+        print(type(api_response.read()))
+        print(api_response.read())
+        return api_response.read()
 
     def _get_log_errors(self, uid: str, status_nodes_dict: Dict) -> List[Dict]:
         errors = []

--- a/src/argowrapper/engine/argo_engine.py
+++ b/src/argowrapper/engine/argo_engine.py
@@ -104,7 +104,8 @@ class ArgoEngine:
             id=wf_id,
             node_id=node_id,
             artifact_discriminator="outputs",
-            artifact_name="main-logs"
+            artifact_name="main-logs",
+            _check_return_type=False,
         )
         return api_response
 

--- a/src/argowrapper/engine/argo_engine.py
+++ b/src/argowrapper/engine/argo_engine.py
@@ -1,9 +1,9 @@
 import string
 import traceback
-from typing import Dict, List
+from typing import Dict, List, Literal
 
 import argo_workflows
-from argo_workflows.api import archived_workflow_service_api, workflow_service_api
+from argo_workflows.api import archived_workflow_service_api, workflow_service_api, artifact_service_api
 from argo_workflows.model.io_argoproj_workflow_v1alpha1_workflow_create_request import (
     IoArgoprojWorkflowV1alpha1WorkflowCreateRequest,
 )
@@ -22,6 +22,7 @@ from argowrapper import logger
 from argowrapper.constants import ARGO_HOST, ARGO_NAMESPACE, WORKFLOW
 from argowrapper.engine.helpers import argo_engine_helper
 from argowrapper.engine.helpers.workflow_factory import WorkflowFactory
+from argowrapper.workflows.argo_workflows.gwas import GWAS
 
 
 class ArgoEngine:
@@ -53,6 +54,7 @@ class ArgoEngine:
         self.archive_api_instance = (
             archived_workflow_service_api.ArchivedWorkflowServiceApi(api_client)
         )
+        self.artifact_api_instance = artifact_service_api.ArtifactServiceApi(api_client)
 
     def _get_all_workflows(self):
         return self.api_instance.list_workflows(namespace=ARGO_NAMESPACE).to_str()
@@ -86,18 +88,56 @@ class ArgoEngine:
             _check_return_type=False,
         ).to_dict()
 
-    def _get_log_errors(self, status_nodes_dict: Dict) -> List[Dict]:
+    def _get_workflow_phase(self, workflow_name: str) -> str:
+        phase_return = self.api_instance.get_workflow(
+            namespace=ARGO_NAMESPACE,
+            name=workflow_name,
+            fields="status.phase",
+            _check_return_type=False,    
+        ).to_dict()
+        return phase_return["status"].get("phase")
+    
+    def _get_workflow_node_artifact(self, id_discriminator: Literal['workflow', 'archived-workflows'], wf_id: str, node_id: str) -> str:
+        api_response = self.archive_api_instance.get_artifact_file(
+            namespace=ARGO_NAMESPACE,
+            id_discriminator=id_discriminator,
+            id=wf_id,
+            node_id=node_id,
+            artifact_discriminator="outputs",
+            artifact_name="main-logs"
+        )
+        return api_response
+
+    def _get_log_errors(self, id_discrimator: str, wf_id: str, status_nodes_dict: Dict) -> List[Dict]:
         errors = []
-        for _, step in status_nodes_dict.items():
-            if step.get("phase") in ("Failed", "Error"):
+        for pod_id, step in status_nodes_dict.items():
+            if step.get("phase") in ("Failed", "Error") and step.get("type")=="Retry":
                 message = (
                     step["message"] if step.get("message") else "No message provided"
+                )
+                pod_type = step.get("type")
+                pod_step = step.get("displayName")
+                pod_step_template =  step.get("templateName")
+                pod_phase = step.get("phase")
+                pod_outputs_mainlog = self._get_workflow_node_artifact(
+                    id_discriminator=id_discrimator,
+                    wf_id=wf_id,
+                    node_id=pod_id
+                )
+                pod_log_interpreted = GWAS.interpret_gwas_workflow_error(
+                    step_name=pod_step,
+                    main_log=pod_outputs_mainlog
                 )
                 errors.append(
                     {
                         "name": step.get("name"),
-                        "step_template": step.get("templateName"),
+                        "pod_id": pod_id,
+                        "pod_type": pod_type,
+                        "pod_phase": pod_phase,
+                        "step_name": pod_step,
+                        "step_template": pod_step_template,
                         "error_message": message,
+                        "error_interpreted": pod_log_interpreted
                     }
                 )
             else:
@@ -332,24 +372,32 @@ class ArgoEngine:
 
     def get_workflow_logs(self, workflow_name: str, uid: str) -> List[Dict]:
         """
-        Gets the workflow errors
+        Gets the workflow errors from failed workflow
 
         Args:
             workflow_name (str): name of an active workflow to get status of
             uid (str): uid of an archived workflow to get status of
 
         Returns:
-            Dict[str, any]: returns a list of dictionaries of errors
+            Dict[str, any]: returns a list of dictionaries of errors of Retry nodes
         """
         try:
             archived_workflow_dict = self._get_archived_workflow_details_dict(uid)
-            archived_workflow_details_nodes = archived_workflow_dict["status"].get(
-                "nodes"
-            )
-            archived_workflow_errors = self._get_log_errors(
-                archived_workflow_details_nodes
-            )
-            return archived_workflow_errors
+            archived_workflow_phase = archived_workflow_dict["status"].get("phase")
+            if archived_workflow_phase in ("Failed", "Error"):
+                archived_workflow_details_nodes = archived_workflow_dict["status"].get(
+                "nodes")
+                archived_workflow_errors = self._get_log_errors(
+                    id_discrimator="archived-workflows",
+                    wf_id=uid,
+                    status_nodes_dict=archived_workflow_details_nodes
+                    )
+                return archived_workflow_errors
+            else:
+                logger.info(
+                    f"Workflow {workflow_name} with uid {uid} doesn't have a Failed or Error phase"
+                )
+                return []
 
         except (KeyError, NotFoundException):
             logger.info(
@@ -358,12 +406,23 @@ class ArgoEngine:
             logger.info(
                 f"Look up the log of {workflow_name} workflow at workflow endpoint"
             )
-            active_workflow_log_return = self._get_workflow_log_dict(workflow_name)
-            active_workflow_details_nodes = active_workflow_log_return["status"].get(
-                "nodes"
-            )
-            active_workflow_errors = self._get_log_errors(active_workflow_details_nodes)
-            return active_workflow_errors
+            active_workflow_phase = self._get_workflow_phase(workflow_name)
+            if active_workflow_phase in ("Failed", "Error"):
+                active_workflow_log_return = self._get_workflow_log_dict(workflow_name)
+                active_workflow_details_nodes = active_workflow_log_return["status"].get(
+                    "nodes"
+                    )
+                active_workflow_errors = self._get_log_errors(
+                    id_discrimator="workflow",
+                    wf_id=workflow_name,
+                    status_nodes_dict=active_workflow_details_nodes
+                    )
+                return active_workflow_errors
+            else:
+                logger.info(
+                    f"Workflow {workflow_name} with uid {uid} doesn't have a Failed or Error phase"
+                )
+                return []
 
         except Exception as exception:
             logger.error(traceback.format_exc())

--- a/src/argowrapper/engine/argo_engine.py
+++ b/src/argowrapper/engine/argo_engine.py
@@ -389,7 +389,7 @@ class ArgoEngine:
                 archived_workflow_details_nodes = archived_workflow_dict["status"].get(
                 "nodes")
                 archived_workflow_errors = self._get_log_errors(
-                    id_discrimator="archived-workflows",
+                    id_discrimator="archived-workflows ",
                     wf_id=uid,
                     status_nodes_dict=archived_workflow_details_nodes
                     )

--- a/src/argowrapper/engine/argo_engine.py
+++ b/src/argowrapper/engine/argo_engine.py
@@ -127,9 +127,9 @@ class ArgoEngine:
                 errors.append(
                     {
                         "name": step.get("name"),
-                        "pod_id": node_id,
-                        "pod_type": node_type,
-                        "pod_phase": node_phase,
+                        "node_id": node_id,
+                        "node_type": node_type,
+                        "node_phase": node_phase,
                         "step_name": node_step,
                         "step_template": node_step_template,
                         "error_message": message,

--- a/src/argowrapper/workflows/argo_workflows/gwas.py
+++ b/src/argowrapper/workflows/argo_workflows/gwas.py
@@ -167,15 +167,15 @@ class GWAS(WorkflowBase):
         return super()._to_dict()
     
     @staticmethod
-    def interpret_gwas_workflow_error(step_name: str, main_log: str) -> str:
+    def interpret_gwas_workflow_error(step_name: str, step_log: str) -> str:
         """A static method to interpret the error message in the main-log file 
         of Failed Retry node
         """
-        if step_name=="run-plots" and "mutate" in main_log:
+        if step_name=="run-plots" and "mutate" in step_log:
             show_error = "Small cohort size or unbalanced cohort sizes."
-        elif step_name=="run-single-assoc" and "system is computationally singular" in main_log:
+        elif step_name=="run-single-assoc" and "system is computationally singular" in step_log:
             show_error = "Unbalanced cohort sizes."
-        elif step_name=="generate-attrition-csv" and "ReadTimeout" in main_log:
+        elif step_name=="generate-attrition-csv" and "ReadTimeout" in step_log:
             show_error = "Timeout on cohort-widdleware request."
         else:
             show_error = "Please contact our help desk at vadc@lists.uchicago.edu for additional support."

--- a/src/argowrapper/workflows/argo_workflows/gwas.py
+++ b/src/argowrapper/workflows/argo_workflows/gwas.py
@@ -175,7 +175,7 @@ class GWAS(WorkflowBase):
         elif step_name=="run-single-assoc" and "system is computationally singular" in step_log:
             show_error = "Unbalanced cohort sizes."
         elif step_name=="generate-attrition-csv" and "ReadTimeout" in step_log:
-            show_error = "Timeout on cohort-widdleware request."
+            show_error = "Timeout occurred while fetching attrition table information."
         else:
             show_error = ""
         return show_error

--- a/src/argowrapper/workflows/argo_workflows/gwas.py
+++ b/src/argowrapper/workflows/argo_workflows/gwas.py
@@ -177,5 +177,5 @@ class GWAS(WorkflowBase):
         elif step_name=="generate-attrition-csv" and "ReadTimeout" in step_log:
             show_error = "Timeout on cohort-widdleware request."
         else:
-            show_error = "Please contact our help desk at vadc@lists.uchicago.edu for additional support."
+            show_error = ""
         return show_error

--- a/src/argowrapper/workflows/argo_workflows/gwas.py
+++ b/src/argowrapper/workflows/argo_workflows/gwas.py
@@ -21,10 +21,9 @@ class GWAS(WorkflowBase):
     """
 
     def __create_gds_files() -> str:
-        chr_list = list(range(1, 23)) + ["X"]
         gds_files = [
             f'"/commons-data/gds/chr{chrom_num}.merged.vcf.gz.gds"'
-            for chrom_num in chr_list
+            for chrom_num in range(1, 23)
         ]
         return f'[{", ".join(gds_files)}]'
 

--- a/src/argowrapper/workflows/argo_workflows/gwas.py
+++ b/src/argowrapper/workflows/argo_workflows/gwas.py
@@ -165,3 +165,18 @@ class GWAS(WorkflowBase):
 
     def generate_argo_workflow(self):
         return super()._to_dict()
+    
+    @staticmethod
+    def interpret_gwas_workflow_error(step_name: str, main_log: str) -> str:
+        """A static method to interpret the error message in the main-log file 
+        of Failed Retry node
+        """
+        if step_name=="run-plots" and "mutate" in main_log:
+            show_error = "Small cohort size or unbalanced cohort sizes."
+        elif step_name=="run-single-assoc" and "system is computationally singular" in main_log:
+            show_error = "Unbalanced cohort sizes."
+        elif step_name=="generate-attrition-csv" and "ReadTimeout" in main_log:
+            show_error = "Timeout on cohort-widdleware request."
+        else:
+            show_error = "Please contact our help desk at vadc@lists.uchicago.edu for additional support."
+        return show_error

--- a/test/test_argo_engine.py
+++ b/test/test_argo_engine.py
@@ -551,5 +551,5 @@ def test_argo_engine_get_workflow_log_succeeded():
     workflow_errors = engine.get_workflow_logs("active_wf", "wf_uid")
     assert len(workflow_errors) == 1
     assert workflow_errors[0]["name"] == "step_one_name"
-    assert workflow_errors[0]["error_interpreted"] == "Timeout on cohort-widdleware request."
+    assert workflow_errors[0]["error_interpreted"] == "Timeout occurred while fetching attrition table information."
     assert workflow_errors[0]["error_message"] == "Error (exit code 126)"

--- a/test/test_argo_engine.py
+++ b/test/test_argo_engine.py
@@ -512,7 +512,7 @@ def test_argo_engine_get_archived_workflow_log_succeeded():
     )
     archived_workflow_errors = engine.get_workflow_logs("archived_wf", "archived_uid")
     assert len(archived_workflow_errors) == 1
-    assert archived_workflow_errors[0]["pod_type"] == "Retry"
+    assert archived_workflow_errors[0]["node_type"] == "Retry"
     assert archived_workflow_errors[0]["step_template"] == "step_one_template"
     assert archived_workflow_errors[0]["error_interpreted"] == "Small cohort size or unbalanced cohort sizes."
 

--- a/test/test_argo_engine.py
+++ b/test/test_argo_engine.py
@@ -495,6 +495,8 @@ def test_argo_engine_get_archived_workflow_log_succeeded():
             "nodes": {
                 "step_one_name": {
                     "name": "step_one_name",
+                    "type": "Retry",
+                    "displayName": "run-plots",
                     "templateName": "step_one_template",
                     "message": "Error (exit code 126)",
                     "phase": "Failed",
@@ -505,11 +507,14 @@ def test_argo_engine_get_archived_workflow_log_succeeded():
     engine._get_archived_workflow_details_dict = mock.MagicMock(
         return_value=mock_return_archived_wf
     )
+    engine._get_workflow_node_artifact = mock.MagicMock(
+        return_value="Problem with mutate()"
+    )
     archived_workflow_errors = engine.get_workflow_logs("archived_wf", "archived_uid")
     assert len(archived_workflow_errors) == 1
-    assert archived_workflow_errors[0]["name"] == "step_one_name"
+    assert archived_workflow_errors[0]["type"] == "Retry"
     assert archived_workflow_errors[0]["step_template"] == "step_one_template"
-    assert archived_workflow_errors[0]["error_message"] == "Error (exit code 126)"
+    assert archived_workflow_errors[0]["error_interpreted"] == "Small cohort size or unbalanced cohort sizes."
 
 
 def test_argo_engine_get_workflow_log_succeeded():
@@ -546,5 +551,5 @@ def test_argo_engine_get_workflow_log_succeeded():
     workflow_errors = engine.get_workflow_logs("active_wf", "wf_uid")
     assert len(workflow_errors) == 1
     assert workflow_errors[0]["name"] == "step_one_name"
-    assert workflow_errors[0]["error_interpreted"] == "Timeout on cohort-widdleware request"
+    assert workflow_errors[0]["error_interpreted"] == "Timeout on cohort-widdleware request."
     assert workflow_errors[0]["error_message"] == "Error (exit code 126)"

--- a/test/test_argo_engine.py
+++ b/test/test_argo_engine.py
@@ -512,7 +512,7 @@ def test_argo_engine_get_archived_workflow_log_succeeded():
     )
     archived_workflow_errors = engine.get_workflow_logs("archived_wf", "archived_uid")
     assert len(archived_workflow_errors) == 1
-    assert archived_workflow_errors[0]["type"] == "Retry"
+    assert archived_workflow_errors[0]["pod_type"] == "Retry"
     assert archived_workflow_errors[0]["step_template"] == "step_one_template"
     assert archived_workflow_errors[0]["error_interpreted"] == "Small cohort size or unbalanced cohort sizes."
 

--- a/test/test_gwas_workflow.py
+++ b/test/test_gwas_workflow.py
@@ -160,5 +160,5 @@ def test_gwas_yaml_spec_arguments():
 def test_interpret_gwas_workflow_error():
     step_name="generate-attrition-csv"
     main_log="requests.exceptions.ReadTimeout\nHTTPConnectionPool"
-    expected_error="Timeout occurred while fetching attrition table information"
+    expected_error="Timeout occurred while fetching attrition table information."
     assert expected_error == GWAS.interpret_gwas_workflow_error(step_name, main_log)

--- a/test/test_gwas_workflow.py
+++ b/test/test_gwas_workflow.py
@@ -160,5 +160,5 @@ def test_gwas_yaml_spec_arguments():
 def test_interpret_gwas_workflow_error():
     step_name="generate-attrition-csv"
     main_log="requests.exceptions.ReadTimeout\nHTTPConnectionPool"
-    expected_error="Timeout on cohort-widdleware request."
+    expected_error="Timeout occurred while fetching attrition table information"
     assert expected_error == GWAS.interpret_gwas_workflow_error(step_name, main_log)

--- a/test/test_gwas_workflow.py
+++ b/test/test_gwas_workflow.py
@@ -156,3 +156,9 @@ def test_gwas_yaml_spec_arguments():
 
     for param_name, param_val in hardcoded_params.items():
         assert param_val == parameters[param_name]
+
+def test_interpret_gwas_workflow_error():
+    step_name="generate-attrition-csv"
+    main_log="requests.exceptions.ReadTimeout\nHTTPConnectionPool"
+    expected_error="Timeout on cohort-widdleware request."
+    assert expected_error == GWAS.interpret_gwas_workflow_error(step_name, main_log)


### PR DESCRIPTION
Jira Ticket: [VADC-640](https://ctds-planx.atlassian.net/browse/VADC-640)

- Modified get_workflow_logs under ArgoEngine Class. The new methods returns a list of failed Retry pods of a failed workflow.
- Added a static method under  GWAS method which interprets error messages from artifact outputs `main-logs` of failed pod 
 


[VADC-640]: https://ctds-planx.atlassian.net/browse/VADC-640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ