### PR TITLE
Fix: adjust parse_common_details to not look for labels

### DIFF
--- a/src/argowrapper/engine/helpers/argo_engine_helper.py
+++ b/src/argowrapper/engine/helpers/argo_engine_helper.py
@@ -57,12 +57,6 @@ def parse_common_details(
         "submittedAt": workflow_details["metadata"].get("creationTimestamp"),
         "startedAt": workflow_details["status"].get("startedAt"),
         "finishedAt": workflow_details["status"].get("finishedAt"),
-        GEN3_USER_METADATA_LABEL: workflow_details["metadata"]
-        .get("labels")
-        .get(GEN3_USER_METADATA_LABEL),
-        GEN3_TEAM_PROJECT_METADATA_LABEL: workflow_details["metadata"]
-        .get("labels")
-        .get(GEN3_TEAM_PROJECT_METADATA_LABEL),
     }
 
 
@@ -78,6 +72,12 @@ def parse_details(
     result["arguments"] = workflow_details["spec"].get("arguments")
     result["progress"] = workflow_details["status"].get("progress")
     result["outputs"] = workflow_details["status"].get("outputs", {})
+    result[GEN3_USER_METADATA_LABEL] = (
+        workflow_details["metadata"].get("labels").get(GEN3_USER_METADATA_LABEL)
+    )
+    result[GEN3_TEAM_PROJECT_METADATA_LABEL] = (
+        workflow_details["metadata"].get("labels").get(GEN3_TEAM_PROJECT_METADATA_LABEL)
+    )
     return result
 
 
@@ -95,7 +95,7 @@ def parse_list_item(
             workflow_details["metadata"].get("annotations", {}).get("workflow_name")
         )
     else:
-        # this is needed because archived list items to not have metadata.annotations
+        # this is needed because archived list items do not have metadata.annotations
         # returned by the list service...so we need to call another service to get it:
         result["wf_name"] = get_archived_workflow_given_name(
             workflow_details["metadata"].get("uid")

--- a/test/test_argo_engine_helper.py
+++ b/test/test_argo_engine_helper.py
@@ -156,11 +156,7 @@ def test_parse_common_details():
         archived_workflow_item, "archived_workflow"
     )
     assert parsed_item.get("phase") == "Canceling"
-    assert parsed_item.get(GEN3_USER_METADATA_LABEL) == "dummyuser"
-    assert parsed_item.get(GEN3_TEAM_PROJECT_METADATA_LABEL) == "dummyteam"
     assert parsed_item_archived.get("name") == "test_wf_archived"
-    assert parsed_item_archived.get(GEN3_USER_METADATA_LABEL) == "dummyuser"
-    assert parsed_item_archived.get(GEN3_TEAM_PROJECT_METADATA_LABEL) is None
 
 
 def test_parse_details():
@@ -195,6 +191,15 @@ def test_parse_details():
     assert parsed_item.get("progress") == "1/5"
     assert parsed_item.get("outputs") == {"out1": "one"}
 
+    parsed_item = argo_engine_helper.parse_details(workflow_item, "archived_workflow")
+    assert parsed_item.get("phase") == "Running"
+    assert parsed_item.get(GEN3_USER_METADATA_LABEL) == "dummyuser"
+    assert parsed_item.get(GEN3_TEAM_PROJECT_METADATA_LABEL) == "dummyteam"
+    assert parsed_item.get("wf_name") == "custom_name"
+    assert parsed_item.get("arguments") == "test_args"
+    assert parsed_item.get("progress") == "1/5"
+    assert parsed_item.get("outputs") == {"out1": "one"}
+
 
 def test_parse_list_item():
     workflow_item = {
@@ -203,7 +208,7 @@ def test_parse_list_item():
             "annotations": {"workflow_name": "custom_name"},
             "uid": "test_uid",
             "namespace": "argo",
-            "creationTimestamp": "test_starttime",
+            "creationTimestamp": "test_creationtime",
             "labels": {
                 GEN3_USER_METADATA_LABEL: "dummyuser",
                 GEN3_TEAM_PROJECT_METADATA_LABEL: "dummyteam",
@@ -218,11 +223,21 @@ def test_parse_list_item():
     }
 
     parsed_item = argo_engine_helper.parse_list_item(workflow_item, "active_workflow")
+    assert parsed_item.get("name") == "test_wf"
     assert parsed_item.get("phase") == "Canceling"
-    assert parsed_item.get(GEN3_USER_METADATA_LABEL) == "dummyuser"
-    assert parsed_item.get(GEN3_TEAM_PROJECT_METADATA_LABEL) == "dummyteam"
+    assert parsed_item.get("submittedAt") == "test_creationtime"
+    assert parsed_item.get("startedAt") == "test_starttime"
+    assert parsed_item.get("finishedAt") == "test_finishtime"
     assert parsed_item.get("wf_name") == "custom_name"
     assert parsed_item.get("uid") == "test_uid"
+
+    def dummy_get_archived_workflow_given_name(workflow_uid):
+        return "dummy_wf_name"
+
+    parsed_item = argo_engine_helper.parse_list_item(
+        workflow_item, "archived_workflow", dummy_get_archived_workflow_given_name
+    )
+    assert parsed_item.get("wf_name") == "dummy_wf_name"
 
 
 def test_remove_list_duplicates():


### PR DESCRIPTION
Jira Ticket: [VADC-795](https://ctds-planx.atlassian.net/browse/VADC-795)


### Bug Fixes
- fix code to avoid `parse_list_item` from triggering a call that would look for labels in `parse_common_details`. Context: not all labels are returned when workflows are listed as _archived_ workflows. For getting all the labels for an archived workflow, we need to call the argo api `get_archived_workflow` or `get_workflow` methods
  - also used this opportunity to further improve some tests

[VADC-795]: https://ctds-planx.atlassian.net/browse/VADC-795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ