### PR TITLE
Fix: convert team_project labels to valid pod labels

### DIFF
--- a/src/argowrapper/engine/argo_engine.py
+++ b/src/argowrapper/engine/argo_engine.py
@@ -324,7 +324,10 @@ class ArgoEngine:
         Raises:
             raises Exception in case of any error.
         """
-        label_selector = f"{GEN3_TEAM_PROJECT_METADATA_LABEL}={team_project}"
+        team_project_label = argo_engine_helper.convert_gen3teamproject_to_pod_label(
+            team_project
+        )
+        label_selector = f"{GEN3_TEAM_PROJECT_METADATA_LABEL}={team_project_label}"
         workflows = self.get_workflows_for_label_selector(label_selector=label_selector)
         for workflow in workflows:
             workflow["team_project"] = team_project
@@ -346,7 +349,7 @@ class ArgoEngine:
             raises Exception in case of any error.
         """
         username = argo_engine_helper.get_username_from_token(auth_header)
-        user_label = argo_engine_helper.convert_gen3username_to_label(username)
+        user_label = argo_engine_helper.convert_gen3username_to_pod_label(username)
         label_selector = f"{GEN3_USER_METADATA_LABEL}={user_label}"
         return self.get_workflows_for_label_selector(
             label_selector=label_selector

--- a/src/argowrapper/routes/routes.py
+++ b/src/argowrapper/routes/routes.py
@@ -67,7 +67,9 @@ def check_auth(fn):
             # the workflow is one of the user's own workflows:
             workflow_user = workflow_details[GEN3_USER_METADATA_LABEL]
             username = argo_engine_helper.get_username_from_token(token)
-            current_user = argo_engine_helper.convert_gen3username_to_label(username)
+            current_user = argo_engine_helper.convert_gen3username_to_pod_label(
+                username
+            )
             if current_user != workflow_user:
                 return HTMLResponse(
                     content="user is not the author of this workflow, and hence cannot access it",

--- a/src/argowrapper/workflows/argo_workflows/gwas.py
+++ b/src/argowrapper/workflows/argo_workflows/gwas.py
@@ -71,7 +71,7 @@ class GWAS(WorkflowBase):
         self, namespace: str, request_body: Dict, auth_header: str, dry_run=False
     ):
         self.username = argo_engine_helper.get_username_from_token(auth_header)
-        self.gen3username_label = argo_engine_helper.convert_gen3username_to_label(
+        self.gen3username_label = argo_engine_helper.convert_gen3username_to_pod_label(
             self.username
         )
         team_project = request_body.get(TEAM_PROJECT_FIELD_NAME)
@@ -81,7 +81,9 @@ class GWAS(WorkflowBase):
                     TEAM_PROJECT_FIELD_NAME
                 )
             )
-        self.gen3teamproject_label = team_project
+        self.gen3teamproject_label = (
+            argo_engine_helper.convert_gen3teamproject_to_pod_label(team_project)
+        )
         self._request_body = request_body
 
         super().__init__(namespace, WORKFLOW_ENTRYPOINT.GWAS_ENTRYPOINT, dry_run)

--- a/test/test_argo_engine.py
+++ b/test/test_argo_engine.py
@@ -6,6 +6,8 @@ from argowrapper import logger
 from argo_workflows.exceptions import NotFoundException
 from argowrapper.constants import *
 from argowrapper.engine.argo_engine import *
+import argowrapper.engine.helpers.argo_engine_helper as argo_engine_helper
+
 from test.constants import EXAMPLE_AUTH_HEADER
 from argowrapper.workflows.argo_workflows.gwas import *
 
@@ -176,7 +178,9 @@ def test_argo_engine_get_workflow_details_succeeded():
             "annotations": {"workflow_name": "custome_wf_name"},
             "labels": {
                 GEN3_USER_METADATA_LABEL: "dummyuser",
-                GEN3_TEAM_PROJECT_METADATA_LABEL: "dummyteam",
+                GEN3_TEAM_PROJECT_METADATA_LABEL: argo_engine_helper.convert_gen3teamproject_to_pod_label(
+                    "dummyteam"
+                ),
             },
         },
         "spec": {"arguments": {}},
@@ -255,7 +259,9 @@ def test_argo_engine_get_workflows_for_user_and_team_projects_suceeded():
                 "creationTimestamp": "2023-03-22T16:48:51Z",
                 "labels": {
                     GEN3_USER_METADATA_LABEL: "dummyuser",
-                    GEN3_TEAM_PROJECT_METADATA_LABEL: "dummyteam",
+                    GEN3_TEAM_PROJECT_METADATA_LABEL: argo_engine_helper.convert_gen3teamproject_to_pod_label(
+                        "dummyteam"
+                    ),
                 },
             },
             "spec": {"arguments": {}, "shutdown": "Terminate"},
@@ -274,7 +280,9 @@ def test_argo_engine_get_workflows_for_user_and_team_projects_suceeded():
                 "creationTimestamp": "2023-03-22T17:47:51Z",
                 "labels": {
                     GEN3_USER_METADATA_LABEL: "dummyuser",
-                    GEN3_TEAM_PROJECT_METADATA_LABEL: "dummyteam",
+                    GEN3_TEAM_PROJECT_METADATA_LABEL: argo_engine_helper.convert_gen3teamproject_to_pod_label(
+                        "dummyteam"
+                    ),
                 },
             },
             "spec": {"arguments": {}},
@@ -296,7 +304,9 @@ def test_argo_engine_get_workflows_for_user_and_team_projects_suceeded():
                 "creationTimestamp": "2023-03-22T18:57:51Z",
                 "labels": {
                     GEN3_USER_METADATA_LABEL: "dummyuser",
-                    GEN3_TEAM_PROJECT_METADATA_LABEL: "dummyteam",
+                    GEN3_TEAM_PROJECT_METADATA_LABEL: argo_engine_helper.convert_gen3teamproject_to_pod_label(
+                        "dummyteam"
+                    ),
                 },
             },
             "spec": {"arguments": {}},
@@ -314,7 +324,9 @@ def test_argo_engine_get_workflows_for_user_and_team_projects_suceeded():
                 "creationTimestamp": "2023-03-22T19:59:59Z",
                 "labels": {
                     GEN3_USER_METADATA_LABEL: "dummyuser",
-                    GEN3_TEAM_PROJECT_METADATA_LABEL: "dummyteam",
+                    GEN3_TEAM_PROJECT_METADATA_LABEL: argo_engine_helper.convert_gen3teamproject_to_pod_label(
+                        "dummyteam"
+                    ),
                 },
             },
             "spec": {"arguments": {}},
@@ -332,7 +344,9 @@ def test_argo_engine_get_workflows_for_user_and_team_projects_suceeded():
             "annotations": {"workflow_name": "custom_name_archived"},
             "labels": {
                 GEN3_USER_METADATA_LABEL: "dummyuser",
-                GEN3_TEAM_PROJECT_METADATA_LABEL: "dummyteam",
+                GEN3_TEAM_PROJECT_METADATA_LABEL: argo_engine_helper.convert_gen3teamproject_to_pod_label(
+                    "dummyteam"
+                ),
             },
         },
         "spec": {},
@@ -352,7 +366,7 @@ def test_argo_engine_get_workflows_for_user_and_team_projects_suceeded():
     with mock.patch(
         "argowrapper.engine.argo_engine.argo_engine_helper.get_username_from_token"
     ), mock.patch(
-        "argowrapper.engine.argo_engine.argo_engine_helper.convert_gen3username_to_label"
+        "argowrapper.engine.argo_engine.argo_engine_helper.convert_gen3username_to_pod_label"
     ):
         uniq_workflow_list = engine.get_workflows_for_user("test_jwt_token")
         assert len(uniq_workflow_list) == 3
@@ -387,13 +401,13 @@ def test_argo_engine_get_workflows_for_user_and_team_projects_suceeded():
             engine.api_instance.list_workflows.call_args[1][
                 "list_options_label_selector"
             ]
-            == f"{GEN3_TEAM_PROJECT_METADATA_LABEL}=dummyteam"
+            == f"{GEN3_TEAM_PROJECT_METADATA_LABEL}={argo_engine_helper.convert_gen3teamproject_to_pod_label('dummyteam')}"
         )
         assert (
             engine.archive_api_instance.list_archived_workflows.call_args[1][
                 "list_options_label_selector"
             ]
-            == f"{GEN3_TEAM_PROJECT_METADATA_LABEL}=dummyteam"
+            == f"{GEN3_TEAM_PROJECT_METADATA_LABEL}={argo_engine_helper.convert_gen3teamproject_to_pod_label('dummyteam')}"
         )
 
 
@@ -468,7 +482,7 @@ def test_argo_engine_get_workflows_for_user_empty():
     with mock.patch(
         "argowrapper.engine.argo_engine.argo_engine_helper.get_username_from_token"
     ), mock.patch(
-        "argowrapper.engine.argo_engine.argo_engine_helper.convert_gen3username_to_label"
+        "argowrapper.engine.argo_engine.argo_engine_helper.convert_gen3username_to_pod_label"
     ):
         uniq_workflow_list = engine.get_workflows_for_user("test_jwt_token")
         assert len(uniq_workflow_list) == 2
@@ -493,7 +507,7 @@ def test_argo_engine_get_workflows_for_user_empty_both():
     with mock.patch(
         "argowrapper.engine.argo_engine.argo_engine_helper.get_username_from_token"
     ), mock.patch(
-        "argowrapper.engine.argo_engine.argo_engine_helper.convert_gen3username_to_label"
+        "argowrapper.engine.argo_engine.argo_engine_helper.convert_gen3username_to_pod_label"
     ):
         uniq_workflow_list = engine.get_workflows_for_user("test_jwt_token")
         assert len(uniq_workflow_list) == 0

--- a/test/test_argo_engine_helper.py
+++ b/test/test_argo_engine_helper.py
@@ -21,7 +21,7 @@ def _convert_to_label(special_character_match: str) -> str:
 
 def convert_username_label_to_gen3username(label: str) -> str:
     """this function will reverse the conversion of a username to label as
-    defined by the convert_gen3username_to_label function. eg "user--21" -> "!"
+    defined by the convert_gen3username_to_pod_label function. eg "user--21" -> "!"
 
     Args:
         label (str): _description_
@@ -56,12 +56,22 @@ user_label_data = [
 
 @pytest.mark.parametrize("username,label", user_label_data)
 def test_convert_username_label_to_gen3username(username, label):
-    assert argo_engine_helper.convert_gen3username_to_label(username) == label
+    assert argo_engine_helper.convert_gen3username_to_pod_label(username) == label
 
 
 @pytest.mark.parametrize("username,label", user_label_data)
-def test_convert_gen3username_to_label(username, label):
+def test_convert_gen3username_to_pod_label(username, label):
     assert convert_username_label_to_gen3username(label) == username
+
+
+def test_convert_gen3teamproject_to_pod_label_and_back():
+    team_project = "/gwas_projects/project2"
+    pod_label = argo_engine_helper.convert_gen3teamproject_to_pod_label(team_project)
+    assert pod_label == "2f677761735f70726f6a656374732f70726f6a65637432"
+    converted_team_project = argo_engine_helper.convert_pod_label_to_gen3teamproject(
+        pod_label
+    )
+    assert team_project == converted_team_project
 
 
 WorkflowStatusData = namedtuple("WorkflowStatusData", "parsed_phase shutdown phase")
@@ -169,7 +179,9 @@ def test_parse_details():
             "creationTimestamp": "test_starttime",
             "labels": {
                 GEN3_USER_METADATA_LABEL: "dummyuser",
-                GEN3_TEAM_PROJECT_METADATA_LABEL: "dummyteam",
+                GEN3_TEAM_PROJECT_METADATA_LABEL: argo_engine_helper.convert_gen3teamproject_to_pod_label(
+                    "dummyteam"
+                ),
             },
         },
         "spec": {"arguments": "test_args", "shutdown": "Terminate"},


### PR DESCRIPTION
Jira Ticket: [VADC-796](https://ctds-planx.atlassian.net/browse/VADC-796)


### Bug Fixes
- convert team_project labels to valid pod labels. This fix allows "team project" names to have many types of special characters, including `/`


[VADC-796]: https://ctds-planx.atlassian.net/browse/VADC-796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ