### PR TITLE
Fix/metadata label parsing

### DIFF
--- a/src/argowrapper/engine/argo_engine.py
+++ b/src/argowrapper/engine/argo_engine.py
@@ -384,7 +384,7 @@ class ArgoEngine:
                 namespace=ARGO_NAMESPACE,
                 list_options_label_selector=label_selector,
                 _check_return_type=False,
-                fields="items.metadata.name,items.metadata.namespace,items.metadata.annotations,items.metadata.uid,items.metadata.creationTimestamp,items.spec.arguments,items.spec.shutdown,items.status.phase,items.status.startedAt,items.status.finishedAt",
+                fields="items.metadata.name,items.metadata.namespace,items.metadata.annotations,items.metadata.uid,items.metadata.creationTimestamp,items.metadata.labels,items.spec.arguments,items.spec.shutdown,items.status.phase,items.status.startedAt,items.status.finishedAt",
             )
             archived_workflow_list_return = (
                 self.archive_api_instance.list_archived_workflows(

--- a/src/argowrapper/engine/helpers/argo_engine_helper.py
+++ b/src/argowrapper/engine/helpers/argo_engine_helper.py
@@ -94,7 +94,7 @@ def parse_list_item(
         result["wf_name"] = (
             workflow_details["metadata"].get("annotations", {}).get("workflow_name")
         )
-        result[GEN3_TEAM_PROJECT_METADATA_LABEL] = (
+        result[GEN3_TEAM_PROJECT_METADATA_LABEL] = convert_pod_label_to_gen3teamproject(
             workflow_details["metadata"]
             .get("labels")
             .get(GEN3_TEAM_PROJECT_METADATA_LABEL)

--- a/test/test_argo_engine_helper.py
+++ b/test/test_argo_engine_helper.py
@@ -223,7 +223,9 @@ def test_parse_list_item():
             "creationTimestamp": "test_creationtime",
             "labels": {
                 GEN3_USER_METADATA_LABEL: "dummyuser",
-                GEN3_TEAM_PROJECT_METADATA_LABEL: "dummyteam",
+                GEN3_TEAM_PROJECT_METADATA_LABEL: argo_engine_helper.convert_gen3teamproject_to_pod_label(
+                    "dummyteam"
+                ),
             },
         },
         "spec": {"shutdown": "Terminate"},


### PR DESCRIPTION
Jira Ticket: [VADC-811](https://ctds-planx.atlassian.net/browse/VADC-811)


### Bug Fixes

- add missing `items.metadata.labels` to fields selection to fix a crash when listing running workflows
- add missing call to `convert_pod_label_to_gen3teamproject` to return the decoded string for the team project label in the response 

[VADC-811]: https://ctds-planx.atlassian.net/browse/VADC-811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ