### PR TITLE
Update interpreted message

### DIFF
--- a/src/argowrapper/engine/argo_engine.py
+++ b/src/argowrapper/engine/argo_engine.py
@@ -182,8 +182,9 @@ class ArgoEngine:
                 node_outputs_mainlog = self._get_workflow_node_artifact(
                     uid=uid, node_id=node_id
                 )
+                step_log = "\n".join(message)
                 node_log_interpreted = GWAS.interpret_gwas_workflow_error(
-                    step_name=node_step, step_log=message
+                    step_name=node_step, step_log=step_log
                 )
                 errors.append(
                     {

--- a/src/argowrapper/workflows/argo_workflows/gwas.py
+++ b/src/argowrapper/workflows/argo_workflows/gwas.py
@@ -207,8 +207,6 @@ class GWAS(WorkflowBase):
             show_error = "An HTTP error occurred while creating an index record. Please retry running your workflow."
         elif step_name == "run-single-assoc" and "where TRUE/FALSE needed" in step_log:
             show_error = "The error was caused by extreme outliers in the outcome or the covariates. Please try using different outcome/covariates variables."
-        elif step_name == "get-gwas-metadata" and "NoneType" in step_log:
-            show_error = "test message"
         else:
             show_error = ""
         return show_error

--- a/src/argowrapper/workflows/argo_workflows/gwas.py
+++ b/src/argowrapper/workflows/argo_workflows/gwas.py
@@ -207,6 +207,8 @@ class GWAS(WorkflowBase):
             show_error = "An HTTP error occurred while creating an index record. Please retry running your workflow."
         elif step_name == "run-single-assoc" and "where TRUE/FALSE needed" in step_log:
             show_error = "The error was caused by extreme outliers in the outcome or the covariates. Please try using different outcome/covariates variables."
+        elif step_name == "get-gwas-metadata" and "NoneType" in step_log:
+            show_error = "test message"
         else:
             show_error = ""
         return show_error


### PR DESCRIPTION
the interpreted message in the error log was not correctly shown. Since The message variable, which is used as step_log, is a list of strings. When passed to interpret_gwas_workflow_error, it should be a single string, not a list. However, if message is accidentally passed as a list, in conditions in interpret_gwas_workflow_error will fail, causing show_error to remain "".

