### PR TITLE
add more conditions in gwas function

### DIFF
--- a/src/argowrapper/workflows/argo_workflows/gwas.py
+++ b/src/argowrapper/workflows/argo_workflows/gwas.py
@@ -199,10 +199,10 @@ class GWAS(WorkflowBase):
         """A static method to interpret the error message in the main-log file
         of Failed Retry node
         """
-        if step_name == "run-null-model" and "system is exactly singular" in step_log:
+        if step_name in ["run-null-model", "run-single-assoc"] and "system is exactly singular" in step_log:
             show_error = "The error occurred due to small cohort size or unbalanced cohort sizes. Please ensure that the cohorts selected for your analysis are sufficiently large and balanced."
         elif (
-            step_name == "run-single-assoc"
+            step_name in ["run-null-model", "run-single-assoc"]
             and "system is computationally singular" in step_log
         ):
             show_error = "The error occurred due to unbalanced cohort sizes. Please ensure that the sizes of the cohorts are as balanced as possible."


### PR DESCRIPTION
### Improvements

The updated condition makes it clear that:

-  "system is exactly singular" error message applies to both "run-null-model" and "run-single-assoc"
-  "system is computationally singular" error message applies to both "run-null-model" and "run-single-assoc"

### Related discussion

https://cdis.slack.com/archives/C01A12E8NUR/p1731421219821819