### PR TITLE
Update temporary directory size limit

### DIFF
--- a/src/argowrapper/argo_workflows_templates/header.yaml
+++ b/src/argowrapper/argo_workflows_templates/header.yaml
@@ -104,6 +104,6 @@ spec:
   volumes:
     - name: workdir
       emptyDir:
-        sizeLimit: "3Gi"
+        sizeLimit: "20Gi"
   workflowTemplateRef:
     name: gwas-template-integration-test

--- a/src/argowrapper/workflows/argo_workflows/gwas.py
+++ b/src/argowrapper/workflows/argo_workflows/gwas.py
@@ -173,7 +173,7 @@ class GWAS(WorkflowBase):
         )
         logger.info(f"pvc {pvc_name} is used as storage gateway pvc")
         self.spec.add_persistent_volume_claim("gateway", pvc_name)
-        self.spec.add_empty_dir("workdir", "10Gi")
+        self.spec.add_empty_dir("workdir", "20Gi")
 
     def _add_spec_podMetadata_annotations(self):
         self.spec.add_pod_metadata_annotation("gen3username", self.username)
@@ -199,7 +199,10 @@ class GWAS(WorkflowBase):
         """A static method to interpret the error message in the main-log file
         of Failed Retry node
         """
-        if step_name in ["run-null-model", "run-single-assoc"] and "system is exactly singular" in step_log:
+        if (
+            step_name in ["run-null-model", "run-single-assoc"]
+            and "system is exactly singular" in step_log
+        ):
             show_error = "The error occurred due to small cohort size or unbalanced cohort sizes. Please ensure that the cohorts selected for your analysis are sufficiently large and balanced."
         elif (
             step_name in ["run-null-model", "run-single-assoc"]

--- a/workflow_examples/gwas_header.yaml
+++ b/workflow_examples/gwas_header.yaml
@@ -101,6 +101,6 @@ spec:
         claimName: va-input-nfs-pvc
     - name: workdir
       emptyDir:
-        sizeLimit: "10Gi"
+        sizeLimit: "20Gi"
   workflowTemplateRef:
     name: gwas-template


### PR DESCRIPTION
### Improvements

Increased the temporary directory size limit in Argo workflows to better handle resource-intensive operations (e.g., when user defines MAF=0, which will increase the output file size). Changes were applied to:

- src/argowrapper/argo_workflows_templates/header.yaml
- src/argowrapper/workflows/argo_workflows/gwas.py
- workflow_examples/gwas_header.yaml