### PR TITLE
Fix: add stacktrace info for /submit failures

### DIFF
--- a/src/argowrapper/routes/routes.py
+++ b/src/argowrapper/routes/routes.py
@@ -258,6 +258,7 @@ def submit_workflow(
         )
     except Exception as exception:
         logger.error(str(exception))
+        traceback.print_exc()
         if str(exception) == EXCEED_WORKFLOW_LIMIT_ERROR:
             return HTMLResponse(
                 content="You have reached the monthly workflow cap.",


### PR DESCRIPTION
Link to JIRA ticket if there is one: 


### Improvements
- improve information in case of failure of /submit endpoint
